### PR TITLE
Implement podcast continue section (#30)

### DIFF
--- a/Hagda/Components/FeedSections.swift
+++ b/Hagda/Components/FeedSections.swift
@@ -512,13 +512,20 @@ extension ContinueItemsView {
         .frame(height: 150)
     }
     
-    // Generate mock continue items for demonstration
+    // Generate continue items including real podcast progress
     private func generateMockContinueItems() -> [ContentItem] {
+        // Get real podcast progress first
+        let podcastProgress = PodcastProgressTracker.shared.getAllInProgressEpisodes()
+        let podcastItems = podcastProgress.prefix(5).map { entry in
+            PodcastProgressTracker.shared.createContentItem(from: entry)
+        }
+        
+        // Then generate mock items for other types
         let calendar = Calendar.current
         let now = Date()
         
-        // Create a variety of items for each content type
-        var allItems: [ContentItem] = []
+        // Start with real podcast items
+        var allItems: [ContentItem] = podcastItems
         
         // Article items
         allItems.append(ContentItem(
@@ -551,39 +558,6 @@ extension ContinueItemsView {
             • Emerging micro-frameworks and their specialized use cases
             """,
             progressPercentage: 0.22
-        ))
-        
-        // Podcast items
-        allItems.append(ContentItem(
-            title: "The Vergecast: AI's Role in Reshaping Media Consumption",
-            subtitle: "The Vergecast • 30 min remaining",
-            date: calendar.date(byAdding: .hour, value: -1, to: now) ?? now,
-            type: .podcast,
-            contentPreview: """
-            Coming up in this episode:
-            
-            • Analysis of how generative AI is changing content creation and consumption
-            • Interview with leading AI researcher on multi-modal models and their capabilities
-            • Discussion on context window size increases and what they mean for real-world applications
-            • Debate on the ethical implications of AI-generated media and potential regulations
-            """,
-            progressPercentage: 0.65
-        ))
-        
-        allItems.append(ContentItem(
-            title: "This Week in Tech: Apple's New Developer Tools Explained",
-            subtitle: "TWiT • 42 min remaining",
-            date: calendar.date(byAdding: .hour, value: -12, to: now) ?? now,
-            type: .podcast,
-            contentPreview: """
-            The episode continues with expert analysis on:
-            
-            • Detailed walkthrough of Apple's new development environment
-            • Practical applications of the new machine learning frameworks
-            • Cross-platform considerations and compatibility improvements
-            • Future roadmap predictions and strategic implications
-            """,
-            progressPercentage: 0.28
         ))
         
         // Reddit items - temporarily removed until we integrate real data

--- a/Hagda/Models/AudioPlayerManager.swift
+++ b/Hagda/Models/AudioPlayerManager.swift
@@ -174,7 +174,15 @@ class AudioPlayerManager: NSObject, ObservableObject {
     }
     
     private func saveProgress(for episode: PodcastEpisode, time: TimeInterval) {
-        UserDefaults.standard.set(time, forKey: "progress_\(episode.id)")
+        // Get source ID from episode metadata if available
+        let sourceId = episode.metadata?["sourceId"] as? String ?? ""
+        
+        // Use enhanced progress tracker
+        PodcastProgressTracker.shared.saveProgress(
+            for: episode,
+            currentTime: time,
+            sourceId: sourceId
+        )
         
         // Mark as played if > 90% complete
         if duration > 0 && time / duration > 0.9 {
@@ -183,8 +191,7 @@ class AudioPlayerManager: NSObject, ObservableObject {
     }
     
     private func loadProgress(for episode: PodcastEpisode) -> TimeInterval? {
-        let time = UserDefaults.standard.double(forKey: "progress_\(episode.id)")
-        return time > 0 ? time : nil
+        return PodcastProgressTracker.shared.loadProgressTime(for: episode.id)
     }
     
     private func markAsPlayed(_ episode: PodcastEpisode) {
@@ -410,5 +417,6 @@ extension AudioPlayerManager {
         let artworkURL: String?
         let description: String?
         let publishDate: Date
+        let metadata: [String: Any]?
     }
 }

--- a/Hagda/Models/PodcastPlayerExtensions.swift
+++ b/Hagda/Models/PodcastPlayerExtensions.swift
@@ -30,7 +30,8 @@ extension PodcastEpisode {
             duration: duration,
             artworkURL: artworkURL,
             description: description,
-            publishDate: item.date
+            publishDate: item.date,
+            metadata: item.metadata
         )
     }
     

--- a/Hagda/Models/PodcastProgressTracker.swift
+++ b/Hagda/Models/PodcastProgressTracker.swift
@@ -1,0 +1,170 @@
+import Foundation
+
+/// Tracks podcast episode progress with enhanced metadata
+@MainActor
+class PodcastProgressTracker {
+    static let shared = PodcastProgressTracker()
+    
+    private let userDefaults = UserDefaults.standard
+    private let progressPrefix = "podcast_progress_"
+    private let metadataPrefix = "podcast_metadata_"
+    
+    private init() {}
+    
+    // MARK: - Progress Entry Model
+    
+    struct ProgressEntry: Codable {
+        let episodeId: String
+        let episodeTitle: String
+        let podcastTitle: String
+        let artworkURL: String?
+        let audioURL: String
+        let currentTime: TimeInterval
+        let duration: TimeInterval
+        let lastPlayedDate: Date
+        let sourceId: String
+        
+        var progressPercentage: Double {
+            guard duration > 0 else { return 0 }
+            return currentTime / duration
+        }
+        
+        var remainingTime: TimeInterval {
+            return max(0, duration - currentTime)
+        }
+        
+        var isInProgress: Bool {
+            return progressPercentage > 0 && progressPercentage < 0.9
+        }
+    }
+    
+    // MARK: - Save Progress
+    
+    func saveProgress(for episode: AudioPlayerManager.PodcastEpisode, 
+                     currentTime: TimeInterval,
+                     sourceId: String) {
+        let entry = ProgressEntry(
+            episodeId: episode.id,
+            episodeTitle: episode.title,
+            podcastTitle: episode.podcastTitle ?? "Unknown Podcast",
+            artworkURL: episode.artworkURL,
+            audioURL: episode.audioURL ?? "",
+            currentTime: currentTime,
+            duration: episode.duration ?? 0,
+            lastPlayedDate: Date(),
+            sourceId: sourceId
+        )
+        
+        // Save encoded entry
+        if let encoded = try? JSONEncoder().encode(entry) {
+            userDefaults.set(encoded, forKey: progressPrefix + episode.id)
+        }
+        
+        // Also save in legacy format for compatibility
+        userDefaults.set(currentTime, forKey: "progress_\(episode.id)")
+        
+        // Mark as played if > 90% complete
+        if entry.progressPercentage > 0.9 {
+            userDefaults.set(true, forKey: "played_\(episode.id)")
+        }
+    }
+    
+    // MARK: - Load Progress
+    
+    func loadProgress(for episodeId: String) -> ProgressEntry? {
+        guard let data = userDefaults.data(forKey: progressPrefix + episodeId),
+              let entry = try? JSONDecoder().decode(ProgressEntry.self, from: data) else {
+            // Try legacy format
+            let time = userDefaults.double(forKey: "progress_\(episodeId)")
+            return time > 0 ? createLegacyEntry(episodeId: episodeId, time: time) : nil
+        }
+        return entry
+    }
+    
+    func loadProgressTime(for episodeId: String) -> TimeInterval? {
+        if let entry = loadProgress(for: episodeId) {
+            return entry.currentTime
+        }
+        // Legacy format
+        let time = userDefaults.double(forKey: "progress_\(episodeId)")
+        return time > 0 ? time : nil
+    }
+    
+    // MARK: - Get All In-Progress
+    
+    func getAllInProgressEpisodes() -> [ProgressEntry] {
+        let keys = userDefaults.dictionaryRepresentation().keys
+        let progressKeys = keys.filter { $0.hasPrefix(progressPrefix) }
+        
+        let entries = progressKeys.compactMap { key -> ProgressEntry? in
+            guard let data = userDefaults.data(forKey: key),
+                  let entry = try? JSONDecoder().decode(ProgressEntry.self, from: data) else {
+                return nil
+            }
+            return entry.isInProgress ? entry : nil
+        }
+        
+        // Sort by last played date, most recent first
+        return entries.sorted { $0.lastPlayedDate > $1.lastPlayedDate }
+    }
+    
+    // MARK: - Clear Progress
+    
+    func clearProgress(for episodeId: String) {
+        userDefaults.removeObject(forKey: progressPrefix + episodeId)
+        userDefaults.removeObject(forKey: "progress_\(episodeId)")
+        userDefaults.removeObject(forKey: "played_\(episodeId)")
+    }
+    
+    func clearOldProgress(olderThan days: Int = 30) {
+        let cutoffDate = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? Date()
+        
+        let entries = getAllInProgressEpisodes()
+        for entry in entries where entry.lastPlayedDate < cutoffDate {
+            clearProgress(for: entry.episodeId)
+        }
+    }
+    
+    // MARK: - Migration Support
+    
+    private func createLegacyEntry(episodeId: String, time: TimeInterval) -> ProgressEntry? {
+        // Create a basic entry for legacy progress data
+        return ProgressEntry(
+            episodeId: episodeId,
+            episodeTitle: "Unknown Episode",
+            podcastTitle: "Unknown Podcast",
+            artworkURL: nil,
+            audioURL: "",
+            currentTime: time,
+            duration: 0,
+            lastPlayedDate: Date().addingTimeInterval(-86400), // 1 day ago
+            sourceId: ""
+        )
+    }
+    
+    // MARK: - ContentItem Conversion
+    
+    func createContentItem(from entry: ProgressEntry) -> ContentItem {
+        let remainingMinutes = Int(entry.remainingTime / 60)
+        let subtitle = "\(remainingMinutes) minutes left • \(entry.podcastTitle)"
+        
+        return ContentItem(
+            title: entry.episodeTitle,
+            subtitle: subtitle,
+            date: entry.lastPlayedDate,
+            type: .podcast,
+            contentPreview: "",
+            progressPercentage: entry.progressPercentage,
+            metadata: [
+                "episodeGuid": entry.episodeId,
+                "episodeTitle": entry.episodeTitle,
+                "audioUrl": entry.audioURL,
+                "podcastName": entry.podcastTitle,
+                "podcastArtworkUrl": entry.artworkURL ?? "",
+                "episodeDuration": String(entry.duration),
+                "sourceId": entry.sourceId,
+                "lastPlayedDate": entry.lastPlayedDate
+            ]
+        )
+    }
+}

--- a/Hagda/Views/ContinueReadingView.swift
+++ b/Hagda/Views/ContinueReadingView.swift
@@ -189,11 +189,17 @@ struct ContinueReadingView: View {
     
     // Generate mock continue items for demonstration - create more items for this view
     private func generateMockContinueItems() -> [ContentItem] {
+        // Get real podcast progress first
+        let podcastProgress = PodcastProgressTracker.shared.getAllInProgressEpisodes()
+        let podcastItems = podcastProgress.map { entry in
+            PodcastProgressTracker.shared.createContentItem(from: entry)
+        }
+        
         let calendar = Calendar.current
         let now = Date()
         
-        // Generate multiple items for each content type for a fuller list
-        var items: [ContentItem] = []
+        // Start with real podcast items
+        var items: [ContentItem] = podcastItems
         
         // Article items
         items.append(ContentItem(
@@ -226,39 +232,6 @@ struct ContinueReadingView: View {
             • Emerging micro-frameworks and their specialized use cases
             """,
             progressPercentage: 0.22
-        ))
-        
-        // Podcast items
-        items.append(ContentItem(
-            title: "The Vergecast: AI's Role in Reshaping Media Consumption",
-            subtitle: "The Vergecast • 30 min remaining",
-            date: calendar.date(byAdding: .hour, value: -1, to: now) ?? now,
-            type: .podcast,
-            contentPreview: """
-            Coming up in this episode:
-            
-            • Analysis of how generative AI is changing content creation and consumption
-            • Interview with leading AI researcher on multi-modal models and their capabilities
-            • Discussion on context window size increases and what they mean for real-world applications
-            • Debate on the ethical implications of AI-generated media and potential regulations
-            """,
-            progressPercentage: 0.65
-        ))
-        
-        items.append(ContentItem(
-            title: "This Week in Tech: Apple's New Developer Tools Explained",
-            subtitle: "TWiT • 42 min remaining",
-            date: calendar.date(byAdding: .hour, value: -12, to: now) ?? now,
-            type: .podcast,
-            contentPreview: """
-            The episode continues with expert analysis on:
-            
-            • Detailed walkthrough of Apple's new development environment
-            • Practical applications of the new machine learning frameworks
-            • Cross-platform considerations and compatibility improvements
-            • Future roadmap predictions and strategic implications
-            """,
-            progressPercentage: 0.28
         ))
         
         // Reddit items

--- a/HagdaTests/BlueSkyPostTests.swift
+++ b/HagdaTests/BlueSkyPostTests.swift
@@ -4,32 +4,11 @@ import XCTest
 /// Tests for the BlueSky API service and post details functionality
 class BlueSkyPostTests: XCTestCase {
     
-    // Mock URL session for testing API calls
-    class MockURLSession: URLSessionProtocol {
-        var data: Data?
-        var response: URLResponse?
-        var error: Error?
-        
-        func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-            completionHandler(data, response, error)
-            return URLSessionDataTask()
-        }
-        
-        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-            if let error = error {
-                throw error
-            }
-            guard let data = data, let response = response else {
-                throw URLError(.unknown)
-            }
-            return (data, response)
-        }
-    }
     
     /// Tests fetching posts from the BlueSky API
     func testFetchBlueSkyPosts() async throws {
         // Create mock data
-        let mockSession = MockURLSession()
+        let mockSession = SharedMockURLSession()
         
         // Sample API response data for getAuthorFeed endpoint
         let mockFeedResponse = """
@@ -60,9 +39,9 @@ class BlueSkyPostTests: XCTestCase {
         }
         """
         
-        mockSession.data = mockFeedResponse.data(using: .utf8)
-        mockSession.response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        mockSession.error = nil
+        mockSession.mockData = mockFeedResponse.data(using: .utf8)
+        mockSession.mockResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        mockSession.mockError = nil
         
         // Create the API service with the mock session
         let service = BlueSkyAPIService(session: mockSession)

--- a/HagdaTests/MastodonPostTests.swift
+++ b/HagdaTests/MastodonPostTests.swift
@@ -128,6 +128,7 @@ class MastodonPostTests: XCTestCase {
         
         // Create a source
         let source = Source(
+            id: UUID(),
             name: "Test User",
             type: .mastodon,
             description: "A test Mastodon account",

--- a/HagdaTests/MastodonPostTests.swift
+++ b/HagdaTests/MastodonPostTests.swift
@@ -4,32 +4,10 @@ import XCTest
 /// Tests for the Mastodon API service and post details functionality
 class MastodonPostTests: XCTestCase {
     
-    // Mock URL session for testing API calls
-    class MockURLSession: URLSessionProtocol {
-        var data: Data?
-        var response: URLResponse?
-        var error: Error?
-        
-        func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-            completionHandler(data, response, error)
-            return URLSessionDataTask()
-        }
-        
-        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-            if let error = error {
-                throw error
-            }
-            guard let data = data, let response = response else {
-                throw URLError(.unknown)
-            }
-            return (data, response)
-        }
-    }
-    
     /// Tests fetching statuses from the Mastodon API
     func testFetchMastodonStatuses() async throws {
         // Create mock data
-        let mockSession = MockURLSession()
+        let mockSession = SharedMockURLSession()
         
         // Sample API response data for account statuses endpoint
         let mockStatusesResponse = """
@@ -60,9 +38,9 @@ class MastodonPostTests: XCTestCase {
         ]
         """
         
-        mockSession.data = mockStatusesResponse.data(using: .utf8)
-        mockSession.response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        mockSession.error = nil
+        mockSession.mockData = mockStatusesResponse.data(using: .utf8)
+        mockSession.mockResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        mockSession.mockError = nil
         
         // Mock the account info endpoint as well
         let mockAccountResponse = """
@@ -145,7 +123,7 @@ class MastodonPostTests: XCTestCase {
             replies_count: 3,
             reblogs_count: 7,
             favourites_count: 15,
-            media_attachments: []
+            media_attachments: nil
         )
         
         // Create a source

--- a/HagdaTests/NewsArticleTests.swift
+++ b/HagdaTests/NewsArticleTests.swift
@@ -4,37 +4,6 @@ import XCTest
 /// Tests for the News API service and article details functionality
 class NewsArticleTests: XCTestCase {
     
-    // Mock URL session for testing API calls
-    class MockURLSession: URLSessionProtocol {
-        var data: Data?
-        var response: URLResponse?
-        var error: Error?
-        
-        func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-            completionHandler(data, response, error)
-            return URLSessionDataTask()
-        }
-        
-        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-            if let error = error {
-                throw error
-            }
-            guard let data = data, let response = response else {
-                throw URLError(.unknown)
-            }
-            return (data, response)
-        }
-        
-        func data(from url: URL) async throws -> (Data, URLResponse) {
-            if let error = error {
-                throw error
-            }
-            guard let data = data, let response = response else {
-                throw URLError(.unknown)
-            }
-            return (data, response)
-        }
-    }
     
     /// Tests parsing RSS data
     func testRSSParsing() {
@@ -83,7 +52,7 @@ class NewsArticleTests: XCTestCase {
     /// Tests fetching articles from an RSS feed
     func testFetchArticles() async throws {
         // Create mock data
-        let mockSession = MockURLSession()
+        let mockSession = SharedMockURLSession()
         
         // Sample RSS data for a feed
         let rssData = """
@@ -110,9 +79,9 @@ class NewsArticleTests: XCTestCase {
         </rss>
         """.data(using: .utf8)!
         
-        mockSession.data = rssData
-        mockSession.response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        mockSession.error = nil
+        mockSession.mockData = rssData
+        mockSession.mockResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        mockSession.mockError = nil
         
         // Create the News API service with the mock session
         let service = NewsAPIService(session: mockSession)

--- a/HagdaTests/PodcastEpisodeTests.swift
+++ b/HagdaTests/PodcastEpisodeTests.swift
@@ -4,42 +4,6 @@ import XCTest
 /// Tests for the iTunes Search API service and podcast episode details functionality
 class PodcastEpisodeTests: XCTestCase {
     
-    // Mock URL session for testing API calls
-    class MockURLSession: URLSessionProtocol {
-        var data: Data?
-        var response: URLResponse?
-        var error: Error?
-        
-        func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-            completionHandler(data, response, error)
-            return URLSessionDataTask()
-        }
-        
-        func dataTask(with url: URL, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-            completionHandler(data, response, error)
-            return URLSessionDataTask()
-        }
-        
-        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-            if let error = error {
-                throw error
-            }
-            guard let data = data, let response = response else {
-                throw URLError(.unknown)
-            }
-            return (data, response)
-        }
-        
-        func data(from url: URL) async throws -> (Data, URLResponse) {
-            if let error = error {
-                throw error
-            }
-            guard let data = data, let response = response else {
-                throw URLError(.unknown)
-            }
-            return (data, response)
-        }
-    }
     
     /// Tests parsing RSS feed data
     func testPodcastRSSParsing() async throws {
@@ -72,10 +36,10 @@ class PodcastEpisodeTests: XCTestCase {
         """.data(using: .utf8)!
         
         // Create mock session
-        let mockSession = MockURLSession()
-        mockSession.data = rssData
-        mockSession.response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        mockSession.error = nil
+        let mockSession = SharedMockURLSession()
+        mockSession.mockData = rssData
+        mockSession.mockResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        mockSession.mockError = nil
         
         // Create the iTunes Search API service with the mock session
         let service = ITunesSearchService(session: mockSession)

--- a/HagdaTests/PodcastProgressTrackerTests.swift
+++ b/HagdaTests/PodcastProgressTrackerTests.swift
@@ -1,0 +1,206 @@
+import Testing
+import Foundation
+@testable import Hagda
+
+@Suite("PodcastProgressTracker Tests")
+@MainActor
+struct PodcastProgressTrackerTests {
+    
+    @Test("Save and load podcast progress")
+    func testSaveAndLoadProgress() throws {
+        // Given
+        let tracker = PodcastProgressTracker.shared
+        let episode = AudioPlayerManager.PodcastEpisode(
+            id: "test-episode-1",
+            title: "Test Episode",
+            podcastTitle: "Test Podcast",
+            audioURL: "https://example.com/episode.mp3",
+            duration: 3600, // 1 hour
+            artworkURL: "https://example.com/artwork.jpg",
+            description: "Test description",
+            publishDate: Date(),
+            metadata: ["sourceId": "source-123"]
+        )
+        
+        // When
+        tracker.saveProgress(for: episode, currentTime: 1800, sourceId: "source-123")
+        let loadedProgress = tracker.loadProgress(for: episode.id)
+        
+        // Then
+        #expect(loadedProgress != nil)
+        #expect(loadedProgress?.episodeId == episode.id)
+        #expect(loadedProgress?.currentTime == 1800)
+        #expect(loadedProgress?.duration == 3600)
+        #expect(loadedProgress?.progressPercentage == 0.5)
+        #expect(loadedProgress?.remainingTime == 1800)
+        #expect(loadedProgress?.isInProgress == true)
+        
+        // Cleanup
+        tracker.clearProgress(for: episode.id)
+    }
+    
+    @Test("Get all in-progress episodes")
+    func testGetAllInProgressEpisodes() throws {
+        // Given
+        let tracker = PodcastProgressTracker.shared
+        let episodes = [
+            AudioPlayerManager.PodcastEpisode(
+                id: "test-episode-2",
+                title: "Episode 2",
+                podcastTitle: "Test Podcast",
+                audioURL: "https://example.com/episode2.mp3",
+                duration: 3600,
+                artworkURL: nil,
+                description: "Test",
+                publishDate: Date(),
+                metadata: ["sourceId": "source-123"]
+            ),
+            AudioPlayerManager.PodcastEpisode(
+                id: "test-episode-3",
+                title: "Episode 3",
+                podcastTitle: "Test Podcast",
+                audioURL: "https://example.com/episode3.mp3",
+                duration: 1800,
+                artworkURL: nil,
+                description: "Test",
+                publishDate: Date(),
+                metadata: ["sourceId": "source-456"]
+            )
+        ]
+        
+        // When
+        tracker.saveProgress(for: episodes[0], currentTime: 600, sourceId: "source-123")
+        tracker.saveProgress(for: episodes[1], currentTime: 900, sourceId: "source-456")
+        
+        let inProgressEpisodes = tracker.getAllInProgressEpisodes()
+        
+        // Then
+        #expect(inProgressEpisodes.count >= 2)
+        #expect(inProgressEpisodes.contains { $0.episodeId == "test-episode-2" })
+        #expect(inProgressEpisodes.contains { $0.episodeId == "test-episode-3" })
+        
+        // Cleanup
+        for episode in episodes {
+            tracker.clearProgress(for: episode.id)
+        }
+    }
+    
+    @Test("Mark episode as played when > 90% complete")
+    func testMarkAsPlayedWhenAlmostComplete() throws {
+        // Given
+        let tracker = PodcastProgressTracker.shared
+        let episode = AudioPlayerManager.PodcastEpisode(
+            id: "test-episode-4",
+            title: "Nearly Complete Episode",
+            podcastTitle: "Test Podcast",
+            audioURL: "https://example.com/episode4.mp3",
+            duration: 1000,
+            artworkURL: nil,
+            description: "Test",
+            publishDate: Date(),
+            metadata: ["sourceId": "source-789"]
+        )
+        
+        // When
+        tracker.saveProgress(for: episode, currentTime: 950, sourceId: "source-789") // 95% complete
+        let loadedProgress = tracker.loadProgress(for: episode.id)
+        
+        // Then
+        #expect(loadedProgress?.progressPercentage ?? 0 > 0.9)
+        #expect(loadedProgress?.isInProgress == false) // Should not be in progress
+        
+        // Verify it's not included in in-progress list
+        let inProgressEpisodes = tracker.getAllInProgressEpisodes()
+        #expect(!inProgressEpisodes.contains { $0.episodeId == episode.id })
+        
+        // Cleanup
+        tracker.clearProgress(for: episode.id)
+    }
+    
+    @Test("Create ContentItem from progress entry")
+    func testCreateContentItemFromProgress() throws {
+        // Given
+        let tracker = PodcastProgressTracker.shared
+        let episode = AudioPlayerManager.PodcastEpisode(
+            id: "test-episode-5",
+            title: "Content Item Test Episode",
+            podcastTitle: "Test Podcast",
+            audioURL: "https://example.com/episode5.mp3",
+            duration: 3600, // 1 hour
+            artworkURL: "https://example.com/artwork.jpg",
+            description: "Test description",
+            publishDate: Date(),
+            metadata: ["sourceId": "source-999"]
+        )
+        
+        // When
+        tracker.saveProgress(for: episode, currentTime: 1200, sourceId: "source-999") // 20 minutes listened
+        let progress = tracker.loadProgress(for: episode.id)
+        let contentItem = tracker.createContentItem(from: progress!)
+        
+        // Then
+        #expect(contentItem.title == "Content Item Test Episode")
+        #expect(contentItem.subtitle.contains("40 minutes left"))
+        #expect(contentItem.subtitle.contains("Test Podcast"))
+        #expect(contentItem.type == .podcast)
+        #expect(contentItem.progressPercentage == progress?.progressPercentage ?? 0)
+        
+        // Check metadata
+        #expect(contentItem.metadata?["episodeGuid"] as? String == episode.id)
+        #expect(contentItem.metadata?["podcastName"] as? String == "Test Podcast")
+        #expect(contentItem.metadata?["audioUrl"] as? String == "https://example.com/episode5.mp3")
+        #expect(contentItem.metadata?["sourceId"] as? String == "source-999")
+        
+        // Cleanup
+        tracker.clearProgress(for: episode.id)
+    }
+    
+    @Test("Clear old progress")
+    func testClearOldProgress() throws {
+        // Given
+        let tracker = PodcastProgressTracker.shared
+        let oldEpisode = AudioPlayerManager.PodcastEpisode(
+            id: "old-episode",
+            title: "Old Episode",
+            podcastTitle: "Test Podcast",
+            audioURL: "https://example.com/old.mp3",
+            duration: 3600,
+            artworkURL: nil,
+            description: "Test",
+            publishDate: Date(),
+            metadata: ["sourceId": "source-old"]
+        )
+        
+        // When - Save progress and then clear immediately (simulating old progress)
+        tracker.saveProgress(for: oldEpisode, currentTime: 1800, sourceId: "source-old")
+        
+        // Verify it exists
+        #expect(tracker.loadProgress(for: oldEpisode.id) != nil)
+        
+        // Clear old progress (0 days old for test)
+        tracker.clearOldProgress(olderThan: 0)
+        
+        // Then - Old progress should be cleared
+        #expect(tracker.loadProgress(for: oldEpisode.id) == nil)
+    }
+    
+    @Test("Handle legacy progress format")
+    func testLegacyProgressFormat() throws {
+        // Given
+        let tracker = PodcastProgressTracker.shared
+        let episodeId = "legacy-episode"
+        let userDefaults = UserDefaults.standard
+        
+        // Simulate legacy format by setting only the old progress key
+        userDefaults.set(1234.5, forKey: "progress_\(episodeId)")
+        
+        // When
+        let loadedTime = tracker.loadProgressTime(for: episodeId)
+        
+        // Then
+        #expect(loadedTime == 1234.5)
+        
+        // Cleanup
+        userDefaults.removeObject(forKey: "progress_\(episodeId)")
+    }
+}

--- a/HagdaTests/RedditPostTests.swift
+++ b/HagdaTests/RedditPostTests.swift
@@ -4,32 +4,10 @@ import XCTest
 /// Tests for the Reddit API service and post details functionality
 class RedditPostTests: XCTestCase {
     
-    // Mock URL session for testing API calls
-    class MockURLSession: URLSessionProtocol {
-        var data: Data?
-        var response: URLResponse?
-        var error: Error?
-        
-        func dataTask(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask {
-            completionHandler(data, response, error)
-            return URLSessionDataTask()
-        }
-        
-        func data(for request: URLRequest) async throws -> (Data, URLResponse) {
-            if let error = error {
-                throw error
-            }
-            guard let data = data, let response = response else {
-                throw URLError(.unknown)
-            }
-            return (data, response)
-        }
-    }
-    
     /// Tests fetching posts from the Reddit API
     func testFetchRedditPosts() async throws {
         // Create mock data
-        let mockSession = MockURLSession()
+        let mockSession = SharedMockURLSession()
         
         // Sample API response data for subreddit posts
         let mockPostsResponse = """
@@ -62,9 +40,9 @@ class RedditPostTests: XCTestCase {
         }
         """
         
-        mockSession.data = mockPostsResponse.data(using: .utf8)
-        mockSession.response = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
-        mockSession.error = nil
+        mockSession.mockData = mockPostsResponse.data(using: .utf8)
+        mockSession.mockResponse = HTTPURLResponse(url: URL(string: "https://example.com")!, statusCode: 200, httpVersion: nil, headerFields: nil)
+        mockSession.mockError = nil
         
         // Create the API service with the mock session
         let service = RedditAPIService(session: mockSession)


### PR DESCRIPTION
## Summary
- Implements real-time tracking of podcast episode progress in the Continue section
- Adds PodcastProgressTracker to persist and retrieve episode playback state

## Changes
- Created `PodcastProgressTracker` class to manage podcast progress with timestamps
- Updated `AudioPlayerManager` to use the new tracker instead of direct UserDefaults
- Added metadata property to `PodcastEpisode` for source tracking
- Modified `FeedSections` and `ContinueReadingView` to display real podcast progress
- Added comprehensive test suite for `PodcastProgressTracker`
- Fixed test URLSessionProtocol conformance issues across multiple test files

## Test plan
- [x] Unit tests for PodcastProgressTracker pass
- [x] Build succeeds without errors
- [ ] Manual testing: Play a podcast, navigate away, check Continue section shows progress
- [ ] Manual testing: Resume playback from Continue section works correctly
- [ ] Manual testing: Progress percentage and remaining time display correctly

Closes #30

🤖 Generated with [Claude Code](https://claude.ai/code)