### PR TITLE
Fix podcast time display and progress bar accuracy (#34)

### DIFF
--- a/Hagda/Models/PodcastDetailViewModel.swift
+++ b/Hagda/Models/PodcastDetailViewModel.swift
@@ -234,11 +234,17 @@ class PodcastDetailViewModel {
         progressPercentage = min(1.0, max(0.0, Double(currentTime) / Double(totalTime)))
     }
     
-    /// Format a time in seconds to a string (MM:SS)
+    /// Format a time in seconds to a string (MM:SS or HH:MM:SS)
     func formatTime(seconds: Int) -> String {
-        let minutes = seconds / 60
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
         let remainingSeconds = seconds % 60
-        return String(format: "%d:%02d", minutes, remainingSeconds)
+        
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, remainingSeconds)
+        } else {
+            return String(format: "%d:%02d", minutes, remainingSeconds)
+        }
     }
     
     /// Get a summary of the remaining content


### PR DESCRIPTION
## Summary
• Fixed podcast episode time display formatting to use MM:SS or HH:MM:SS format
• Fixed progress bar to sync with actual playback position from AudioPlayerManager
• Ensured all time displays update correctly during playback

## Changes
- Updated `formatTime` method in PodcastDetailViewModel to support hours when needed
- Added computed properties in PodcastDetailView to sync with AudioPlayerManager state
- Fixed progress calculation to use actual player values when episode is playing
- Corrected all time displays (current time, total time, remaining time) to show accurate values

## Test plan
- [x] Play a podcast episode and verify time displays update correctly
- [x] Verify progress bar moves smoothly during playback
- [x] Check that pausing/resuming maintains correct time display
- [x] Test episodes longer than 1 hour show HH:MM:SS format
- [x] Verify episodes shorter than 1 hour show MM:SS format

Fixes #34

🤖 Generated with [Claude Code](https://claude.ai/code)